### PR TITLE
fix: use svelte export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
 	],
 	"exports": {
 		"import": "./dist/index.mjs",
-		"default": "./dist/index.js"
+		"default": "./dist/index.js",
+		".": {
+			"svelte": "./dist/index.mjs"
+		}
 	},
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
@@ -70,5 +73,5 @@
 	"engines": {
 		"node": ">=16.0.0"
 	},
-	"svelte": "src/components/Sidebar/index.js"
+	"svelte": "./dist/index.mjs"
 }


### PR DESCRIPTION
Closes #527.

As described in the issue, `vite-plugin-svelte` is preferring to import from a `svelte` export condition, as [described here](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition).

This change adds such an export condition, and updates the `svelte` key to point to the same `dist` output.